### PR TITLE
GBBE-126 - Enable tracking of deposits & withdrawals

### DIFF
--- a/configs/envs/.env.golembase_l3_local
+++ b/configs/envs/.env.golembase_l3_local
@@ -57,3 +57,11 @@ NEXT_PUBLIC_SEO_ENHANCED_DATA_ENABLED=true
 NEXT_PUBLIC_WEB3_WALLETS=['brave', 'metamask', 'token_pocket']
 NEXT_PUBLIC_WEB3_DISABLE_ADD_TOKEN_TO_WALLET=false
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=7945398e082c6ee207fe141114321954
+
+# Golem Base - show deposits/withdrawals
+NEXT_PUBLIC_ROLLUP_TYPE=optimistic
+NEXT_PUBLIC_ROLLUP_PARENT_CHAIN={'baseUrl':'https://explorer.golem-base.io','currency':{'name':'Ether','symbol':'ETH','decimals':18},'isTestnet':true,'id':393530,'name':'Golem Base L2 Testnet-001 \"Erech\"','rpcUrls':['https://execution.holesky.l2.gobas.me']}
+NEXT_PUBLIC_ROLLUP_HOMEPAGE_SHOW_LATEST_BLOCKS=true
+NEXT_PUBLIC_ROLLUP_L1_BASE_URL='http://explorer.golem-base.io'
+NEXT_PUBLIC_ROLLUP_L2_WITHDRAWAL_URL='http://example.com' # FIXME should be an URL to UI for making withdrawals, but there's none for now (or maybe no withdrawals at all ever?)
+NEXT_PUBLIC_ROLLUP_OUTPUT_ROOTS_ENABLED=true              # FIXME why? what's that?


### PR DESCRIPTION
## Description and Related Issue(s)

Enables Optimism-related features that will allow tracking deposits & withdrawals

### Proposed Changes
Just a change of default .env

### Breaking or Incompatible Changes
Needs blockscout built with CHAIN_TYPE=optimism.

### Additional Information
It's not a complete fix for GBBE-126 - we will need some changes in naming, as it's displayed as L1<>L2 instead of L2<>L3.

## Checklist for PR author
- [X] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
