### PR TITLE
GBBE-240 - Allow specifying base path for golem base indexer service

### DIFF
--- a/configs/app/apis.ts
+++ b/configs/app/apis.ts
@@ -76,6 +76,7 @@ const golemBaseIndexerApi = (() => {
 
   return Object.freeze({
     endpoint: apiHost,
+    basePath: stripTrailingSlash(getEnvValue('NEXT_PUBLIC_GOLEM_BASE_INDEXER_API_BASE_PATH') || ''),
   });
 })();
 

--- a/deploy/tools/envs-validator/schema.ts
+++ b/deploy/tools/envs-validator/schema.ts
@@ -300,6 +300,7 @@ const golemSchema = yup
   .object()
   .shape({
     NEXT_PUBLIC_GOLEM_BASE_INDEXER_API_HOST: yup.string().test(urlTest),
+    NEXT_PUBLIC_GOLEM_BASE_INDEXER_API_BASE_PATH: yup.string(),
     NEXT_PUBLIC_COLOR_THEME_LIGHT_HEX: yup.string(),
     NEXT_PUBLIC_COLOR_THEME_LIGHT_SAMPLE_BG: yup.string(),
     NEXT_PUBLIC_COLOR_THEME_DARK_HEX: yup.string(),

--- a/docs/ENVS.md
+++ b/docs/ENVS.md
@@ -963,6 +963,7 @@ This feature allows to display widgets on the address page with data from 3rd pa
 | Variable | Type| Description | Compulsoriness  | Default value | Example value | Version |
 | --- | --- | --- | --- | --- | --- | --- |
 | NEXT_PUBLIC_GOLEM_BASE_INDEXER_API_HOST | `string` | Golem Base Indexer API endpoint url | - | - | `https://golem-indexer.services.blockscout.com` | v2.2.0+ |
+| NEXT_PUBLIC_GOLEM_BASE_INDEXER_API_BASE_PATH | `string` | Golem Base Indexer API base path            | -              | -                                                                         | `/golem-base-indexer`                                                     | v2.2.0+ |
 | NEXT_PUBLIC_COLOR_THEME_LIGHT_HEX | `string` | Hex color code for light theme background | - | `#FFFFFF` | `#FFFFFF` | v2.2.0+ |
 | NEXT_PUBLIC_COLOR_THEME_LIGHT_SAMPLE_BG | `string` | CSS background value for light theme sample | - | `linear-gradient(154deg, #EFEFEF 50%, rgba(255, 255, 255, 0.00) 330.86%)` | `linear-gradient(154deg, #EFEFEF 50%, rgba(255, 255, 255, 0.00) 330.86%)` | v2.2.0+ |
 | NEXT_PUBLIC_COLOR_THEME_DARK_HEX | `string` | Hex color code for dark theme background | - | `#101112` | `#101112` | v2.2.0+ |

--- a/playwright/fixtures/mockEnvs.ts
+++ b/playwright/fixtures/mockEnvs.ts
@@ -114,5 +114,6 @@ export const ENVS_MAP: Record<string, Array<[string, string]>> = {
   ],
   golemBaseIndexer: [
     [ 'NEXT_PUBLIC_GOLEM_BASE_INDEXER_API_HOST', 'http://localhost:8050' ],
+    [ 'NEXT_PUBLIC_GOLEM_BASE_INDEXER_API_BASE_PATH', '' ],
   ],
 };


### PR DESCRIPTION
## Description and Related Issue(s)

Dragan wants to host everything under a single domain and differentiate based on path. Right now that's not possible, as frontend assumes golem base indexer is hosted at root of the domain

### Proposed Changes

Allow specifying a base path, similarly to other services.

### Breaking or Incompatible Changes

None

### Additional Information

Adds a new env.

## Checklist for PR author
- [X] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [X] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
