### PR TITLE
GBBE-241 - Show operations count on address tabs

### DIFF
--- a/mocks/address/tabCounters.ts
+++ b/mocks/address/tabCounters.ts
@@ -8,4 +8,5 @@ export const base: AddressTabsCounters = {
   transactions_count: 51,
   validations_count: 42,
   withdrawals_count: 11,
+  golembase_operations_count: 13,
 };

--- a/stubs/address.ts
+++ b/stubs/address.ts
@@ -55,6 +55,7 @@ export const ADDRESS_TABS_COUNTERS: AddressTabsCounters = {
   transactions_count: 10,
   validations_count: 10,
   withdrawals_count: 10,
+  golembase_operations_count: 10,
 };
 
 export const TOP_ADDRESS: AddressesItem = {
@@ -66,7 +67,7 @@ export const TOP_ADDRESS: AddressesItem = {
   is_verified: null,
   name: null,
   private_tags: [],
-  public_tags: [ ],
+  public_tags: [],
   watchlist_names: [],
   ens_domain_name: null,
 };

--- a/types/api/address.ts
+++ b/types/api/address.ts
@@ -202,6 +202,7 @@ export type AddressTabsCounters = {
   validations_count: number | null;
   withdrawals_count: number | null;
   celo_election_rewards_count?: number | null;
+  golembase_operations_count: number | null;
 };
 
 // MUD framework

--- a/ui/pages/Address.tsx
+++ b/ui/pages/Address.tsx
@@ -227,6 +227,7 @@ const AddressPageContent = () => {
       {
         id: 'entity_ops',
         title: 'Entity operations',
+        count: addressTabsCountersQuery.data?.golembase_operations_count,
         component: <AddressEntityOps shouldRender={ !isTabsLoading } isQueryEnabled={ areQueriesEnabled }/>,
         subTabs: ENTITY_OPS_TABS,
       },


### PR DESCRIPTION
## Description and Related Issue(s)

All tabs on address view show count of items except our Entity operations.

### Proposed Changes

Add count of operations in the Entity operations tab.

### Breaking or Incompatible Changes

N/A

### Additional Information

Backend PR that added this feature: https://github.com/Golem-Base/blockscout/pull/30

<img width="624" height="382" alt="image" src="https://github.com/user-attachments/assets/44e4ec2e-ef84-46f2-8acc-60615a38cf22" />


## Checklist for PR author
- [X] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
