### PR TITLE
Make FF metamask work

### DIFF
--- a/nextjs/csp/generateCspPolicy.ts
+++ b/nextjs/csp/generateCspPolicy.ts
@@ -20,6 +20,7 @@ function generateCspPolicy() {
     descriptors.safe(),
     descriptors.usernameApi(),
     descriptors.walletConnect(),
+    descriptors.ffMetamask(),
   );
 
   return makePolicyString(policyDescriptor);

--- a/nextjs/csp/policies/ffMetamask.ts
+++ b/nextjs/csp/policies/ffMetamask.ts
@@ -1,0 +1,10 @@
+import type CspDev from 'csp-dev';
+
+export function ffMetamask(): CspDev.DirectiveDescriptor {
+
+  return {
+    'script-src': [
+      `'sha256-PRh/fvLCFBNVoIAGULuMBLuPh7G0pBe3UpLsY8yvX0A='`, // MetaMask Firefox  12.23.1
+    ],
+  };
+}

--- a/nextjs/csp/policies/index.ts
+++ b/nextjs/csp/policies/index.ts
@@ -15,3 +15,4 @@ export { rollbar } from './rollbar';
 export { safe } from './safe';
 export { usernameApi } from './usernameApi';
 export { walletConnect } from './walletConnect';
+export { ffMetamask } from './ffMetamask';


### PR DESCRIPTION
## Description and Related Issue(s)

MetaMask can't it's scripts in Firefox due to our CSP policy

### Proposed Changes

Whitelist current version of metamask in CSP.

### Breaking or Incompatible Changes

N/A

### Additional Information

This will stop working again on first update, but there's no safe alternative. We'll just need to update.

## Checklist for PR author
- [X] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
