### PR TITLE
GBBE-274 - Env-configurable notice on landing page

### DIFF
--- a/configs/app/features/index.ts
+++ b/configs/app/features/index.ts
@@ -48,3 +48,4 @@ export { default as validators } from './validators';
 export { default as verifiedTokens } from './verifiedTokens';
 export { default as web3Wallet } from './web3Wallet';
 export { default as xStarScore } from './xStarScore';
+export { default as topNotice } from './topNotice';

--- a/configs/app/features/topNotice.ts
+++ b/configs/app/features/topNotice.ts
@@ -1,0 +1,24 @@
+import type { Feature } from './types';
+
+import { getEnvValue } from '../utils';
+
+const notice = getEnvValue('NEXT_PUBLIC_TOP_NOTICE_HTML');
+
+const title = 'Top Notice';
+
+const config: Feature<{ notice: string }> = (() => {
+  if (notice) {
+    return Object.freeze({
+      title,
+      isEnabled: true,
+      notice,
+    });
+  }
+
+  return Object.freeze({
+    title,
+    isEnabled: false,
+  });
+})();
+
+export default config;

--- a/configs/envs/.env.golembase_l3_local
+++ b/configs/envs/.env.golembase_l3_local
@@ -75,3 +75,5 @@ NEXT_PUBLIC_ROLLUP_OUTPUT_ROOTS_ENABLED=true              # FIXME why? what's th
 # UMAMI
 NEXT_PUBLIC_UMAMI_SCRIPT_SRC=https://cloud.umami.is/script.js
 NEXT_PUBLIC_UMAMI_WEBSITE_ID=25e4aea8-49a0-4b6f-8983-249b9a3160b3
+
+NEXT_PUBLIC_TOP_NOTICE_HTML="Get test ETH for this chain on <a style='font-weight: bold; color: var(--chakra-colors-link-primary)' href='https://kaolin.holesky.golem-base.io/faucet/'>our faucet</a>!"

--- a/deploy/tools/envs-validator/schema.ts
+++ b/deploy/tools/envs-validator/schema.ts
@@ -305,6 +305,7 @@ const golemSchema = yup
     NEXT_PUBLIC_COLOR_THEME_LIGHT_SAMPLE_BG: yup.string(),
     NEXT_PUBLIC_COLOR_THEME_DARK_HEX: yup.string(),
     NEXT_PUBLIC_COLOR_THEME_DARK_SAMPLE_BG: yup.string(),
+    NEXT_PUBLIC_TOP_NOTICE_HTML: yup.string(),
   });
 
 const parentChainCurrencySchema = yup

--- a/docs/ENVS.md
+++ b/docs/ENVS.md
@@ -977,6 +977,7 @@ This feature allows to display widgets on the address page with data from 3rd pa
 | NEXT_PUBLIC_COLOR_THEME_LIGHT_SAMPLE_BG | `string` | CSS background value for light theme sample | - | `linear-gradient(154deg, #EFEFEF 50%, rgba(255, 255, 255, 0.00) 330.86%)` | `linear-gradient(154deg, #EFEFEF 50%, rgba(255, 255, 255, 0.00) 330.86%)` | v2.2.0+ |
 | NEXT_PUBLIC_COLOR_THEME_DARK_HEX | `string` | Hex color code for dark theme background | - | `#101112` | `#101112` | v2.2.0+ |
 | NEXT_PUBLIC_COLOR_THEME_DARK_SAMPLE_BG | `string` | CSS background value for dark theme sample | - | `linear-gradient(161deg, #000 9.37%, #383838 92.52%)` | `linear-gradient(161deg, #000 9.37%, #383838 92.52%)` | v2.2.0+ |
+| NEXT_PUBLIC_TOP_NOTICE_HTML                  | `string` | HTML element that will be displayed at the top of landing page | -              | ``                                                                        | `Check out our faucet at <a href="faucet.example.org">faucet.example.org</a>` | v2.2.0+ |
 
 &nbsp;
 

--- a/ui/pages/Home.tsx
+++ b/ui/pages/Home.tsx
@@ -10,6 +10,7 @@ import LatestBlocks from 'ui/home/LatestBlocks';
 import Stats from 'ui/home/Stats';
 import Transactions from 'ui/home/Transactions';
 import AdBanner from 'ui/shared/ad/AdBanner';
+import TopNotice from 'ui/shared/TopNotice';
 
 const rollupFeature = config.features.rollup;
 
@@ -31,6 +32,7 @@ const Home = () => {
   return (
     <Box as="main">
       <HeroBanner/>
+      <TopNotice/>
       <Flex flexDir={{ base: 'column', lg: 'row' }} columnGap={ 2 } rowGap={ 1 } mt={ 3 } _empty={{ mt: 0 }}>
         <Stats/>
         <ChainIndicators/>

--- a/ui/shared/TopNotice.tsx
+++ b/ui/shared/TopNotice.tsx
@@ -1,0 +1,23 @@
+import { Flex } from '@chakra-ui/react';
+import React from 'react';
+
+import config from 'configs/app';
+import { Alert } from 'toolkit/chakra/alert';
+
+const feature = config.features.topNotice;
+
+const TopNotice = () => {
+  if (!feature.isEnabled) {
+    return null;
+  }
+
+  return (
+    <Flex flexDir={{ base: 'column', lg: 'row' }} columnGap={ 2 } rowGap={ 1 } mt={ 3 } _empty={{ mt: 0 }}>
+      <Alert showIcon={ true } title={
+        <div dangerouslySetInnerHTML={{ __html: feature.notice }}></div>
+      }/>
+    </Flex>
+  );
+};
+
+export default React.memo(TopNotice);


### PR DESCRIPTION
## Description and Related Issue(s)

Clients wants to show a CTA on landing page - must be configurable per L3.

### Proposed Changes

Add a generic alert with contents filled with ENV variable.

### Breaking or Incompatible Changes

N/A

### Additional Information

<img width="1947" height="892" alt="Screenshot 2025-08-20 at 16 44 36" src="https://github.com/user-attachments/assets/9f7c3abc-31be-4f0e-b3ee-7ed5128be610" />


## Checklist for PR author
- [X] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
