### PR TITLE
GBBE-243 Change display unit for gas tracker from Gwei to wei

### DIFF
--- a/configs/app/features/gasTracker.ts
+++ b/configs/app/features/gasTracker.ts
@@ -11,8 +11,7 @@ const units = ((): Array<GasUnit> => {
   const envValue = getEnvValue('NEXT_PUBLIC_GAS_TRACKER_UNITS');
   if (!envValue) {
     if (chainConfig.isTestnet) {
-      return [ 'usd', 'wei' ];
-      // return [ 'wei' ];
+      return [ 'wei' ];
     }
     return [ 'usd', 'wei' ];
   }

--- a/configs/app/features/gasTracker.ts
+++ b/configs/app/features/gasTracker.ts
@@ -11,9 +11,10 @@ const units = ((): Array<GasUnit> => {
   const envValue = getEnvValue('NEXT_PUBLIC_GAS_TRACKER_UNITS');
   if (!envValue) {
     if (chainConfig.isTestnet) {
-      return [ 'gwei' ];
+      return [ 'usd', 'wei' ];
+      // return [ 'wei' ];
     }
-    return [ 'usd', 'gwei' ];
+    return [ 'usd', 'wei' ];
   }
 
   const units = parseEnvJson<Array<GasUnit>>(envValue)?.filter((type) => GAS_UNITS.includes(type)) || [];

--- a/mocks/stats/index.ts
+++ b/mocks/stats/index.ts
@@ -14,6 +14,7 @@ export const base: HomeStats = {
       time: 12030.25,
       base_fee: 2.22222,
       priority_fee: 12.424242,
+      wei: 237532800,
     },
     fast: {
       fiat_price: '1.74',
@@ -21,6 +22,7 @@ export const base: HomeStats = {
       time: 8763.25,
       base_fee: 4.44444,
       priority_fee: 22.242424,
+      wei: 297232800,
     },
     slow: {
       fiat_price: '1.35',
@@ -28,6 +30,7 @@ export const base: HomeStats = {
       time: 20100.25,
       base_fee: 1.11111,
       priority_fee: 7.8909,
+      wei: 230432800,
     },
   },
   gas_price_updated_at: '2022-11-11T11:09:49.051171Z',

--- a/stubs/stats.ts
+++ b/stubs/stats.ts
@@ -12,6 +12,7 @@ export const HOMEPAGE_STATS: HomeStats = {
       time: 12283,
       base_fee: 2.22222,
       priority_fee: 12.424242,
+      wei: 204132800,
     },
     fast: {
       fiat_price: '1.26',
@@ -19,6 +20,7 @@ export const HOMEPAGE_STATS: HomeStats = {
       time: 9321,
       base_fee: 4.44444,
       priority_fee: 22.242424,
+      wei: 254732800,
     },
     slow: {
       fiat_price: '0.97',
@@ -26,6 +28,7 @@ export const HOMEPAGE_STATS: HomeStats = {
       time: 24543,
       base_fee: 1.11111,
       priority_fee: 7.8909,
+      wei: 195532800,
     },
   },
   gas_price_updated_at: '2022-11-11T11:09:49.051171Z',

--- a/types/api/stats.ts
+++ b/types/api/stats.ts
@@ -38,4 +38,5 @@ export interface GasPriceInfo {
   time: number | null;
   base_fee: number | null;
   priority_fee: number | null;
+  wei: number | null;
 }

--- a/types/client/gasTracker.ts
+++ b/types/client/gasTracker.ts
@@ -1,6 +1,7 @@
 export const GAS_UNITS = [
   'usd',
   'gwei',
+  'wei',
 ] as const;
 
 export type GasUnit = typeof GAS_UNITS[number];

--- a/ui/gasTracker/GasTrackerPriceSnippet.pw.tsx
+++ b/ui/gasTracker/GasTrackerPriceSnippet.pw.tsx
@@ -56,6 +56,7 @@ test('with zero values', async({ render, page }) => {
     time: 0,
     base_fee: 0,
     priority_fee: 0,
+    wei: 0,
   };
 
   await render(
@@ -75,6 +76,7 @@ test('with small values', async({ render, page }) => {
     time: 0,
     base_fee: 0,
     priority_fee: 0,
+    wei: 0,
   };
 
   await render(

--- a/ui/shared/gas/GasPrice.tsx
+++ b/ui/shared/gas/GasPrice.tsx
@@ -9,9 +9,10 @@ import { useMultichainContext } from 'lib/contexts/multichain';
 
 import formatGasValue from './formatGasValue';
 
-const UNITS_TO_API_FIELD_MAP: Record<GasUnit, 'price' | 'fiat_price'> = {
+const UNITS_TO_API_FIELD_MAP: Record<GasUnit, 'price' | 'fiat_price' | 'wei'> = {
   gwei: 'price',
   usd: 'fiat_price',
+  wei: 'wei',
 };
 
 interface Props {

--- a/ui/shared/gas/formatGasValue.ts
+++ b/ui/shared/gas/formatGasValue.ts
@@ -28,5 +28,13 @@ export default function formatGasValue(data: GasPriceInfo, unit: GasUnit) {
 
       return `$${ Number(data.fiat_price).toLocaleString(undefined, { maximumFractionDigits: 2 }) }`;
     }
+
+    case 'wei': {
+      if (!data.wei) {
+        return `N/A ${ currencyUnits.wei }`;
+      }
+    }
+
+      return `${ Number(data.wei).toLocaleString(undefined, { maximumFractionDigits: 2 }) } ${ currencyUnits.wei }`;
   }
 }


### PR DESCRIPTION
## Description and Related Issue(s)

Change display unit for gas tracker from `Gwei` to `wei`. List of gas units has been extended and default settings for `NEXT_PUBLIC_GAS_TRACKER_UNITS` has been changed by replacing `gwei` to `wei`.

### Proposed Changes
Changes will not be visible if on some environment variable `NEXT_PUBLIC_GAS_TRACKER_UNITS` has been set before. It is important to review this setting before deployment.

### Additional Information
<img width="876" height="559" alt="Zrzut ekranu 2025-08-28 o 09 16 19" src="https://github.com/user-attachments/assets/1e947501-a3fb-4613-911d-7e25ff3e00d0" />

## Checklist for PR author
- [x] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
